### PR TITLE
Clean up some code

### DIFF
--- a/module/directory.go
+++ b/module/directory.go
@@ -78,7 +78,7 @@ func (d *Directory) Print() {
 	}
 }
 
-func (d *Directory) ExportBuildRules() error {
+func (d *Directory) ExportBuildRules(thirdParty string) error {
 	// Delete all existing third party build files.
 	err := host.RemoveAllThirdPartyFiles()
 	if err != nil {
@@ -100,7 +100,7 @@ func (d *Directory) ExportBuildRules() error {
 		sort.Strings(versions)
 		for _, version := range versions {
 			mod := vd.versions[version]
-			buildFilePath := mod.GetBuildPath()
+			buildFilePath := mod.GetBuildPath(thirdParty)
 			if _, err := os.Stat(buildFilePath); os.IsNotExist(err) { 
 				err = os.MkdirAll(strings.TrimSuffix(buildFilePath, "/BUILD"), 0700) // Create the nested directory
 				if err != nil {

--- a/module/module.go
+++ b/module/module.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"text/template"
@@ -107,17 +107,8 @@ func (m *Module) GetDownloadName() string {
 }
 
 // GetBuildPath returns the path to the please BUILD file where this module is defined.
-func (m *Module) GetBuildPath() string {
-	splitPath := strings.Split(m.Path, "/")
-	pathMinusEnd := strings.Join(splitPath[:len(splitPath)-1], "/")
-	if splitPath[0] == "github.com" {
-		pathMinusEnd = strings.Join(splitPath[:2], "/")
-	}
-	currentDir, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	return fmt.Sprintf("%s/third_party/go/%s/BUILD", currentDir, pathMinusEnd)
+func (m *Module) GetBuildPath(thirdParty string) string {
+	return filepath.Join(thirdParty, filepath.Dir(m.Path), "BUILD")
 }
 
 // GetFullyQualifiedName returns the please build target for this module.


### PR DESCRIPTION
- We now have a `--third_party` flag that can be used to configure the third party dir. 
- Use `filepath` to construct the module's BUILD file path rather than munging it ourselves. 
- Remove the global directory in favour of having that as a parameter to the functions